### PR TITLE
[kernel] 提供对多个 `hart` 并发启动的支持

### DIFF
--- a/drivers/uart/src/uart.rs
+++ b/drivers/uart/src/uart.rs
@@ -8,7 +8,7 @@ use core::ptr::{read_volatile, write_volatile};
   `0x10000000' 是 `qemu-system-riscv64' 中 `virt' 机器模型的串口地址
 
   理论上不可以直接硬编码下面的内容，不然会失去其它硬件的可移植性
-  正确方式是解析 `glenda_main(reg a0, reg a1)' 中传进来的文件树，但我还没写
+  正确方式是解析 `glenda_main(reg a0, reg a1)' 中传进来的设备树，但我还没写
 */
 pub struct Uart;
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -9,3 +9,7 @@ driver-uart = { path = "../drivers/uart" }
 
 [build-dependencies]
 cc = "1.2.38"
+
+[features]
+default = []
+tests = []

--- a/kernel/src/boot.S
+++ b/kernel/src/boot.S
@@ -1,11 +1,32 @@
     .section .text.start
     .globl _start
-_start:
-    csrw sie, zero
-    la   t0, trap
-    csrw stvec, t0
-    la   sp, boot_stack_top
-    tail glenda_main
+    .globl secondary_start
+
+    .equ BOOT_STACK_SIZE, 4096 // 4KB 启动栈
+    .equ MAX_BOOT_HARTS, 8  // 最多 8 个 hart 并发启动
+
+    .macro HART_ENTRY
+        csrw sie, zero
+        la   t0, trap
+        csrw stvec, t0
+        la   t1, boot_stack_top
+        li   t2, BOOT_STACK_SIZE
+        li   t3, MAX_BOOT_HARTS
+        bgeu a0, t3, 1f
+        mul  t2, t2, a0
+        sub  sp, t1, t2
+        j    2f
+1:
+        mv   sp, t1
+2:
+        tail glenda_main
+    .endm
+
+_start: // boot hart
+    HART_ENTRY
+
+secondary_start: // secondary harts
+    HART_ENTRY
 
     .align 2
 trap:
@@ -15,5 +36,5 @@ trap:
     .section .bss
     .align 16
 boot_stack:
-    .space 4096
+    .space BOOT_STACK_SIZE * MAX_BOOT_HARTS
 boot_stack_top:

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -4,8 +4,6 @@
 mod lock;
 mod logo;
 mod printk;
-
-#[cfg(feature = "tests")]
 mod tests;
 
 use core::panic::PanicInfo;
@@ -26,6 +24,7 @@ use riscv::asm::wfi;
 */
 #[unsafe(no_mangle)]
 pub extern "C" fn glenda_main(hartid: usize, dtb: *const u8) -> ! {
+    tests::init_harts(hartid, dtb);
     if hartid == 0 {
         printk!("{}", LOGO);
         printk!("{}Glenda microkernel booting{}", ANSI_BLUE, ANSI_RESET);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -5,10 +5,14 @@ mod lock;
 mod logo;
 mod printk;
 
+#[cfg(feature = "tests")]
+mod tests;
+
 use core::panic::PanicInfo;
 use logo::LOGO;
 use printk::{ANSI_BLUE, ANSI_RED, ANSI_RESET};
 use riscv::asm::wfi;
+
 /*
  为了便捷，M-mode 固件与 M->S 的降权交给 OpenSBI，程序只负责 S-mode 下的内核
  (虽然大概率以后要从头写出来 M-mode 到 S-mode 的切换)
@@ -22,10 +26,17 @@ use riscv::asm::wfi;
 */
 #[unsafe(no_mangle)]
 pub extern "C" fn glenda_main(hartid: usize, dtb: *const u8) -> ! {
-    printk!("{}", LOGO);
-    printk!("{}Glenda microkernel booting{}", ANSI_BLUE, ANSI_RESET);
-    printk!("HART ID: {}", hartid);
-    printk!("DTB at {:p}", dtb);
+    if hartid == 0 {
+        printk!("{}", LOGO);
+        printk!("{}Glenda microkernel booting{}", ANSI_BLUE, ANSI_RESET);
+        printk!("Device tree blob at {:p}", dtb);
+    }
+
+    #[cfg(feature = "tests")]
+    {
+        tests::run_spinlock_tests(hartid, dtb);
+    }
+
     loop {
         wfi();
     }

--- a/kernel/src/tests/mod.rs
+++ b/kernel/src/tests/mod.rs
@@ -3,3 +3,7 @@ pub mod spinlock;
 pub fn run_spinlock_tests(hartid: usize, dtb: *const u8) {
     spinlock::run(hartid, dtb);
 }
+
+pub fn init_harts(hartid: usize, dtb: *const u8) {
+    spinlock::init(hartid, dtb);
+}

--- a/kernel/src/tests/mod.rs
+++ b/kernel/src/tests/mod.rs
@@ -1,0 +1,5 @@
+pub mod spinlock;
+
+pub fn run_spinlock_tests(hartid: usize, dtb: *const u8) {
+    spinlock::run(hartid, dtb);
+}

--- a/kernel/src/tests/spinlock.rs
+++ b/kernel/src/tests/spinlock.rs
@@ -1,0 +1,145 @@
+use core::arch::asm;
+use core::hint::spin_loop;
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+use crate::lock::SpinLock;
+use crate::printk;
+use crate::printk::{ANSI_BLUE, ANSI_GREEN, ANSI_RED, ANSI_RESET, ANSI_YELLOW};
+
+const HARTS_UNDER_TEST: usize = 4;
+const INCREMENTS_PER_HART: usize = 16;
+
+/*
+ Hart State Management[1]
+
+ [1]: https://www.scs.stanford.edu/~zyedidia/docs/riscv/riscv-sbi.pdf, Chapter Nine
+*/
+const SBI_EXT_HSM: usize = 0x48534d;
+const SBI_FUNC_HART_START: usize = 0;
+
+// 被测试的自旋锁
+static TEST_LOCK: SpinLock = SpinLock::new();
+// 计数
+static GLOBAL_COUNTER: AtomicUsize = AtomicUsize::new(0);
+// 参与 hart 数量，此变量用来确保所有 hart 同步启动
+static PARTICIPANTS: AtomicUsize = AtomicUsize::new(0);
+static START_TEST: AtomicBool = AtomicBool::new(false);
+static HARTS_FINISHED: AtomicUsize = AtomicUsize::new(0);
+static BOOTSTRAP_DONE: AtomicBool = AtomicBool::new(false);
+
+/*
+ 由主 hart 通过 HSM 启动次级 hart 的入口
+
+ Also see:
+ Glenda/kernel/src/boot.S
+*/
+unsafe extern "C" {
+    fn secondary_start(hartid: usize, dtb: *const u8) -> !;
+}
+
+#[inline(always)]
+unsafe fn sbi_hart_start(hartid: usize, start_addr: usize, opaque: usize) -> Result<(), isize> {
+    let mut err: isize;
+    unsafe {
+        asm!(
+            "ecall",
+            in("a0") hartid,
+            in("a1") start_addr,
+            in("a2") opaque,
+            in("a6") SBI_FUNC_HART_START,
+            in("a7") SBI_EXT_HSM,
+            lateout("a0") err,
+            lateout("a1") _,
+        options(nostack)
+        );
+    }
+    if err == 0 { Ok(()) } else { Err(err) }
+}
+
+// 由第一个进来的 hart 调用一次，启动其余参与测试的次级 hart
+fn bootstrap_secondary_harts(hartid: usize, dtb: *const u8) {
+    if BOOTSTRAP_DONE.compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst).is_err() {
+        return;
+    }
+    unsafe {
+        let start_addr = secondary_start as usize;
+        let opaque = dtb as usize;
+        for target in 0..HARTS_UNDER_TEST {
+            if target == hartid {
+                continue;
+            }
+            match sbi_hart_start(target, start_addr, opaque) {
+                Ok(()) => printk!("{}Started hart {} via SBI{}", ANSI_BLUE, target, ANSI_RESET),
+                Err(err) => printk!(
+                    "{}Failed to start hart {} via SBI: error {}{}",
+                    ANSI_RED,
+                    target,
+                    err,
+                    ANSI_RESET
+                ),
+            }
+        }
+    }
+}
+
+// 自旋锁一致性测试
+fn spinlock_test(hartid: usize) {
+    if hartid >= HARTS_UNDER_TEST {
+        printk!("{}hart {} idle{} (not part of spinlock test)", ANSI_YELLOW, hartid, ANSI_RESET);
+        return;
+    }
+
+    // 确保所有 hart 统一开始
+    let ready = PARTICIPANTS.fetch_add(1, Ordering::SeqCst) + 1;
+    if ready == HARTS_UNDER_TEST {
+        printk!(
+            "{}All {} harts ready. Starting spinlock test{}",
+            ANSI_BLUE,
+            HARTS_UNDER_TEST,
+            ANSI_RESET
+        );
+        START_TEST.store(true, Ordering::SeqCst);
+    } else {
+        while !START_TEST.load(Ordering::SeqCst) {
+            spin_loop();
+        }
+    }
+
+    // 拿锁 && 解锁
+    for iter in 0..INCREMENTS_PER_HART {
+        TEST_LOCK.lock();
+        let value_before = GLOBAL_COUNTER.load(Ordering::Relaxed);
+        driver_uart::print!("[hart {}] iter {} -> counter {}\n", hartid, iter, value_before + 1);
+        GLOBAL_COUNTER.store(value_before + 1, Ordering::Relaxed);
+        TEST_LOCK.unlock();
+    }
+
+    // 校验 + 打印结果
+    let finished = HARTS_FINISHED.fetch_add(1, Ordering::SeqCst) + 1;
+    if finished == HARTS_UNDER_TEST {
+        let expected = HARTS_UNDER_TEST * INCREMENTS_PER_HART;
+        let final_value = GLOBAL_COUNTER.load(Ordering::SeqCst);
+        if final_value == expected {
+            printk!(
+                "{}Spinlock test passed{}: counter reached {}",
+                ANSI_GREEN,
+                ANSI_RESET,
+                final_value
+            );
+        } else {
+            printk!(
+                "{}Spinlock test failed{}: counter {} (expected {})",
+                ANSI_RED,
+                ANSI_RESET,
+                final_value,
+                expected
+            );
+        }
+    }
+}
+
+pub fn run(hartid: usize, dtb: *const u8) {
+    printk!("HART ID: {}", hartid);
+    bootstrap_secondary_harts(hartid, dtb);
+    spinlock_test(hartid);
+}

--- a/kernel/src/tests/spinlock.rs
+++ b/kernel/src/tests/spinlock.rs
@@ -138,8 +138,11 @@ fn spinlock_test(hartid: usize) {
     }
 }
 
-pub fn run(hartid: usize, dtb: *const u8) {
-    printk!("HART ID: {}", hartid);
-    bootstrap_secondary_harts(hartid, dtb);
+pub fn run(hartid: usize, _dtb: *const u8) {
     spinlock_test(hartid);
+}
+
+// FIXME: 把启动次级 hart 的逻辑移出 tests
+pub fn init(hartid: usize, dtb: *const u8) {
+    bootstrap_secondary_harts(hartid, dtb);
 }


### PR DESCRIPTION
- `cargo --release --features=tests xtask run` 运行自旋锁测试
- 将 `xtask run` 默认的 hart 数量从 1 改为 4